### PR TITLE
Update SigSpecGenerator.cs

### DIFF
--- a/src/SigSpec.Core/SigSpecGenerator.cs
+++ b/src/SigSpec.Core/SigSpecGenerator.cs
@@ -99,7 +99,7 @@ namespace SigSpec.Core
         {
             var operation = new SigSpecOperation
             {
-                Description = await type.GetXmlSummaryAsync(),
+                Description = await method.GetXmlSummaryAsync(),
                 Type = operationType
             };
 


### PR DESCRIPTION
Fixed so that the XmlDesrciption is taken from the "signalR" method instead of the type (the Hub)