### PR TITLE
Specify a return type for methods on the callbacks

### DIFF
--- a/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
@@ -27,6 +27,6 @@
 
 export interface I{{ Name }}HubCallbacks {
 {% for operation in Callbacks -%}
-    {{ operation.MethodName }}({% for parameter in operation.Parameters %}{{ parameter.Name }}: {{ parameter.Type }}{% if forloop.last == false %}, {% endif %}{% endfor %});
+    {{ operation.MethodName }}({% for parameter in operation.Parameters %}{{ parameter.Name }}: {{ parameter.Type }}{% if forloop.last == false %}, {% endif %}{% endfor %}): void;
 {% endfor -%}
 }


### PR DESCRIPTION
Otherwise you get an error if `noImplicitAny` is set.

![image](https://user-images.githubusercontent.com/393086/62748768-eecc8480-baad-11e9-857e-50fa5651507f.png)
