### PR TITLE
Add onCallBacks so you can listen to a single callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Original idea: https://github.com/RSuter/NSwag/issues/691
 
 ## Sample
 
-Hub: 
+Hub:
 
 ```csharp
 public class ChatHub : Hub<IChatClient>
@@ -29,12 +29,14 @@ public class ChatHub : Hub<IChatClient>
 
     public Task AddPerson(Person person)
     {
+        Clients.Others.PersonAdded(person);
         return Task.CompletedTask;
     }
 
     public ChannelReader<Event> GetEvents()
     {
         var channel = Channel.CreateUnbounded<Event>();
+        // TODO: Write events
         return channel.Reader;
     }
 }
@@ -58,10 +60,12 @@ public interface IChatClient
     Task Welcome();
 
     Task Send(string message);
+
+    Task PersonAdded(Person person);
 }
 ```
 
-Generated spec: 
+Generated spec:
 
 ```json
 {
@@ -74,10 +78,7 @@ Generated spec:
           "description": "",
           "parameters": {
             "message": {
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": "string",
               "description": ""
             }
           }
@@ -89,9 +90,6 @@ Generated spec:
               "description": "",
               "oneOf": [
                 {
-                  "type": "null"
-                },
-                {
                   "$ref": "#/definitions/Person"
                 }
               ]
@@ -102,11 +100,8 @@ Generated spec:
           "description": "",
           "parameters": {},
           "returntype": {
-            "description": "",
+            "description": "Provides a base class for reading from a channel.",
             "oneOf": [
-              {
-                "type": "null"
-              },
               {
                 "$ref": "#/definitions/Event"
               }
@@ -124,11 +119,21 @@ Generated spec:
           "description": "",
           "parameters": {
             "message": {
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": "string",
               "description": ""
+            }
+          }
+        },
+        "PersonAdded": {
+          "description": "",
+          "parameters": {
+            "person": {
+              "description": "",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Person"
+                }
+              ]
             }
           }
         }
@@ -141,16 +146,10 @@ Generated spec:
       "additionalProperties": false,
       "properties": {
         "firstName": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "lastName": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
@@ -158,11 +157,8 @@ Generated spec:
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "Type": {
-          "type": [
-            "null",
-            "string"
-          ]
+        "type": {
+          "type": ["null", "string"]
         }
       }
     }
@@ -170,49 +166,73 @@ Generated spec:
 }
 ```
 
-Generated TypeScript code: 
+Generated TypeScript code:
 
 ```typescript
-import { HubConnection, IStreamResult } from "@aspnet/signalr"
+import { HubConnection, IStreamResult } from '@microsoft/signalr';
 
 export class ChatHub {
-    constructor(private connection: HubConnection) {
-    }
+  constructor(private connection: HubConnection) {}
 
-    send(message: string): Promise<void> {
-        return this.connection.invoke('Send', message);
-    }
+  send(message: string): Promise<void> {
+    return this.connection.invoke('Send', message);
+  }
 
-    addPerson(person: Person): Promise<void> {
-        return this.connection.invoke('AddPerson', person);
-    }
+  addPerson(person: Person): Promise<void> {
+    return this.connection.invoke('AddPerson', person);
+  }
 
-    getEvents(): IStreamResult<Event> {
-        return this.connection.stream('GetEvents');
-    }
+  getEvents(): IStreamResult<Event> {
+    return this.connection.stream('GetEvents');
+  }
 
-    registerCallbacks(implementation: IChatHubCallbacks) {
-        this.connection.on('Welcome', () => implementation.welcome());
-        this.connection.on('Send', (message) => implementation.send(message));
-    }
+  onWelcome(func: () => void): void {
+    this.connection.on('Welcome', func);
+  }
 
-    unregisterCallbacks(implementation: IChatHubCallbacks) {
-        this.connection.off('Welcome', () => implementation.welcome());
-        this.connection.off('Send', (message) => implementation.send(message));
-    }
+  unregisterWelcome(func: () => void): void {
+    this.connection.off('Welcome', func);
+  }
+  onSend(func: (message: string) => void): void {
+    this.connection.on('Send', func);
+  }
+
+  unregisterSend(func: (message: string) => void): void {
+    this.connection.off('Send', func);
+  }
+  onPersonAdded(func: (person: Person) => void): void {
+    this.connection.on('PersonAdded', func);
+  }
+
+  unregisterPersonAdded(func: (person: Person) => void): void {
+    this.connection.off('PersonAdded', func);
+  }
+
+  registerCallbacks(implementation: IChatHubCallbacks) {
+    this.connection.on('Welcome', implementation.welcome);
+    this.connection.on('Send', implementation.send);
+    this.connection.on('PersonAdded', implementation.personAdded);
+  }
+
+  unregisterCallbacks(implementation: IChatHubCallbacks) {
+    this.connection.off('Welcome', implementation.welcome);
+    this.connection.off('Send', implementation.send);
+    this.connection.off('PersonAdded', implementation.personAdded);
+  }
 }
 
 export interface IChatHubCallbacks {
-    welcome(): void;
-    send(message: string): void;
+  welcome(): void;
+  send(message: string): void;
+  personAdded(person: Person): void;
 }
 
 export interface Person {
-    firstName: string;
-    lastName: string;
+  firstName: string | null;
+  lastName: string | null;
 }
 
 export interface Event {
-    Type: string;
+  type: string | null;
 }
 ```

--- a/src/HelloSignalR/ChatHub.cs
+++ b/src/HelloSignalR/ChatHub.cs
@@ -19,6 +19,7 @@ namespace HelloSignalR
 
         public Task AddPerson(Person person)
         {
+            Clients.Others.PersonAdded(person);
             return Task.CompletedTask;
         }
 
@@ -49,5 +50,7 @@ namespace HelloSignalR
         Task Welcome();
 
         Task Send(string message);
+
+        Task PersonAdded(Person person);
     }
 }

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGeneratorSettings.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGeneratorSettings.cs
@@ -14,6 +14,7 @@ namespace SigSpec.CodeGeneration.TypeScript
                 typeof(TypeScriptGeneratorSettings).GetTypeInfo().Assembly,
                 typeof(SigSpecToTypeScriptGeneratorSettingsBase).GetTypeInfo().Assembly,
             });
+            TypeScriptGeneratorSettings.NullValue = TypeScriptNullValue.Null;
         }
 
         public TypeScriptGeneratorSettings TypeScriptGeneratorSettings => (TypeScriptGeneratorSettings)CodeGeneratorSettings;

--- a/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
@@ -1,6 +1,5 @@
 ﻿export class {{ Name }}Hub {
-    constructor(private connection: HubConnection) {
-    }
+    constructor(private connection: HubConnection) {}
 {% for operation in Operations -%}
 
 {%     if operation.IsObservable -%}
@@ -18,15 +17,26 @@
 {%     endif -%}
 {% endfor -%}
 
+{% for operation in Callbacks -%}
+    on{{operation.Name}}(func : ({% for parameter in operation.Parameters %}{{ parameter.Name }}: {{ parameter.Type }}{% if forloop.last == false %}, {% endif %}{% endfor %})  => void ): void {
+        this.connection.on('{{ operation.Name }}', func);
+    }
+
+    unregister{{operation.Name}}(func : ({% for parameter in operation.Parameters %}{{ parameter.Name }}: {{ parameter.Type }}{% if forloop.last == false %}, {% endif %}{% endfor %})  => void ): void {
+        this.connection.off('{{ operation.Name }}', func);
+    }
+{% endfor -%}
+
+
     registerCallbacks(implementation: I{{ Name }}HubCallbacks) {
 {% for operation in Callbacks -%}
-        this.connection.on('{{ operation.Name }}', ({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}) => implementation.{{operation.MethodName}}({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}));
+        this.connection.on('{{ operation.Name }}', implementation.{{operation.MethodName}});
 {% endfor -%}
     }
 
     unregisterCallbacks(implementation: I{{ Name }}HubCallbacks) {
 {% for operation in Callbacks -%}
-        this.connection.off('{{ operation.Name }}', ({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}) => implementation.{{operation.MethodName}}({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}));
+        this.connection.off('{{ operation.Name }}', implementation.{{operation.MethodName}});
 {% endfor -%}
     }
 }


### PR DESCRIPTION
This change will allow a client to listen to a single event callback, instead of having to pass in functions for all options on the Hub.

Also updated the README to reflect this,

And also added the default as Null instead of undefined for typescript as i think null is a better indication than undefined, and aligns with C# more