### PR TITLE
Ignore CancellationToken type when generating parameters

### DIFF
--- a/src/SigSpec.Core/SigSpecGenerator.cs
+++ b/src/SigSpec.Core/SigSpecGenerator.cs
@@ -109,7 +109,7 @@ namespace SigSpec.Core
                 Type = operationType
             };
 
-            foreach (var arg in method.GetParameters())
+            foreach (var arg in method.GetParameters().Where(param => param.ParameterType != typeof(CancellationToken)))
             {
                 var parameter = generator.GenerateWithReferenceAndNullability<SigSpecParameter>(
                     arg.ParameterType.ToContextualType(), arg.ParameterType.ToContextualType().IsNullableType, resolver, (p, s) =>

--- a/src/SigSpec.Core/SigSpecGenerator.cs
+++ b/src/SigSpec.Core/SigSpecGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Namotion.Reflection;


### PR DESCRIPTION
When using a ChannelReader<> method on Hub with a cancellation token, the generated TypeScript contains definitions for CancellationToken/WaitHandle/etc, these aren't needed since you can just call .dispose() to cancel an ISubscription. The CancellationToken parameter makes the TyeScript for streaming unusable.

This is the smallest change to workaround this, I'm open to pitching in something more thought out. I understand this may not work outside of the TypeScript generation (for something like C# generation it would need these parameters).