### PR TITLE
Improvements and Package Updates

### DIFF
--- a/src/HelloSignalR/Startup.cs
+++ b/src/HelloSignalR/Startup.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace HelloSignalR
 {
@@ -11,7 +14,8 @@ namespace HelloSignalR
             services.AddSignalR();
 
             // TODO: Automatically look hubs up
-            services.AddSigSpecDocument(o => o.Hubs["/chat"] = typeof(ChatHub));
+            var hubs = new List<Type> { typeof(ChatHub) };
+            services.AddSigSpecDocument(o => o.Hubs = new ReadOnlyCollection<Type>(hubs));
 
             services.AddCors(c =>
             {

--- a/src/SigSpec.AspNetCore/SigSpecDocumentGeneratorSettings.cs
+++ b/src/SigSpec.AspNetCore/SigSpecDocumentGeneratorSettings.cs
@@ -8,7 +8,7 @@ namespace SigSpec.AspNetCore.Middlewares
     {
         public string DocumentName { get; set; } = "v1";
 
-        public Dictionary<string, Type> Hubs { get; set; } = new Dictionary<string, Type>();
+        public IReadOnlyCollection<Type> Hubs { get; set; }
 
         public SigSpecDocument Template { get; set; } = new SigSpecDocument();
     }

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
@@ -22,8 +22,8 @@
     <EmbeddedResource Include="Templates\Hub.liquid" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.1.16" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.1.16" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.4.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
@@ -20,13 +20,13 @@
 
     registerCallbacks(implementation: I{{ Name }}HubCallbacks) {
 {% for operation in Callbacks -%}
-        this.connection.on('{{ operation.Name }}', ({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}) => implementation.{{operation.MethodName}}({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}));
+        this.connection.on('{{ operation.Name }}', ({% for parameter in operation.Parameters %}{{ parameter.Name }}: {{ parameter.Type }}{% if forloop.last == false %}, {% endif %}{% endfor %}) => implementation.{{operation.MethodName}}({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}));
 {% endfor -%}
     }
 
-    unregisterCallbacks(implementation: I{{ Name }}HubCallbacks) {
+    unregisterCallbacks() {
 {% for operation in Callbacks -%}
-        this.connection.off('{{ operation.Name }}', ({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}) => implementation.{{operation.MethodName}}({% for parameter in operation.Parameters %}{{ parameter.Name }}{% if forloop.last == false %}, {% endif %}{% endfor %}));
+        this.connection.off('{{ operation.Name }}');
 {% endfor -%}
     }
 }

--- a/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
+++ b/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
@@ -14,7 +14,8 @@
     <PackageTags>SignalR Specification CodeGeneration</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.1.16" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.4.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.Console/Program.cs
+++ b/src/SigSpec.Console/Program.cs
@@ -2,7 +2,6 @@
 using SigSpec.CodeGeneration.TypeScript;
 using SigSpec.Core;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SigSpec
@@ -21,10 +20,7 @@ namespace SigSpec
             var generator = new SigSpecGenerator(settings);
 
             // TODO: Add PR to SignalR Core with new IHubDescriptionCollectionProvider service
-            var document = await generator.GenerateForHubsAsync(new Dictionary<string, Type>
-            {
-                { "chat", typeof(ChatHub) }
-            });
+            var document = await generator.GenerateForHubsAsync(typeof(ChatHub));
 
             var json = document.ToJson();
 

--- a/src/SigSpec.Core/Attributes/SigSpecRegisterAttribute.cs
+++ b/src/SigSpec.Core/Attributes/SigSpecRegisterAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SigSpec.Core.Attributes
+{
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+  public class SigSpecRegisterAttribute : Attribute
+  {
+  }
+}

--- a/src/SigSpec.Core/SigSpec.Core.csproj
+++ b/src/SigSpec.Core/SigSpec.Core.csproj
@@ -14,8 +14,9 @@
     <PackageTags>SignalR Specification CodeGeneration</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.1.16" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SignalRService" Version="1.3.0" />
+    <PackageReference Include="NJsonSchema" Version="10.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/SigSpec.Core/SigSpecGenerator.cs
+++ b/src/SigSpec.Core/SigSpecGenerator.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using NJsonSchema;
+﻿using NJsonSchema;
 using NJsonSchema.Generation;
 using System;
 using System.Collections.Generic;
@@ -9,6 +8,9 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Namotion.Reflection;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Extensions.Logging;
+using SigSpec.Core.Attributes;
 
 namespace SigSpec.Core
 {
@@ -21,68 +23,68 @@ namespace SigSpec.Core
             _settings = settings;
         }
 
-        public async Task<SigSpecDocument> GenerateForHubsAsync(IReadOnlyDictionary<string, Type> hubs)
+        public SigSpecDocument GenerateForHubs(params Type[] hubs)
         {
             var document = new SigSpecDocument();
-            return await GenerateForHubsAsync(hubs, document);
+            return GenerateForHubs(hubs, document);
         }
 
-        public async Task<SigSpecDocument> GenerateForHubsAsync(IReadOnlyDictionary<string, Type> hubs, SigSpecDocument template)
+        public SigSpecDocument GenerateForHubs(IReadOnlyCollection<Type> hubs, SigSpecDocument template)
         {
             var document = template;
             var resolver = new SigSpecSchemaResolver(document, _settings);
             var generator = new JsonSchemaGenerator(_settings);
 
-            foreach (var h in hubs)
+            foreach (var type in hubs)
             {
-                var type = h.Value;
-
                 var hub = new SigSpecHub();
                 hub.Name = type.Name.EndsWith("Hub") ? type.Name.Substring(0, type.Name.Length - 3) : type.Name;
                 hub.Description = type.GetXmlDocsSummary();
 
-                foreach (var method in GetOperationMethods(type))
+                foreach (var method in GetHubMethods(type))
                 {
-                    var operation = await GenerateOperationAsync(type, method, generator, resolver, SigSpecOperationType.Sync);
+                    var operation = GenerateOperation(method, generator, resolver, SigSpecOperationType.Sync);
                     hub.Operations[method.Name] = operation;
                 }
 
                 foreach (var method in GetChannelMethods(type))
                 {
-                    hub.Operations[method.Name] = await GenerateOperationAsync(type, method, generator, resolver, SigSpecOperationType.Observable);
+                    hub.Operations[method.Name] = GenerateOperation(method, generator, resolver, SigSpecOperationType.Observable);
                 }
 
                 var baseTypeGenericArguments = type.BaseType.GetGenericArguments();
                 if (baseTypeGenericArguments.Length == 1)
                 {
                     var callbackType = baseTypeGenericArguments[0];
-                    foreach (var callbackMethod in GetOperationMethods(callbackType))
+                    foreach (var callbackMethod in GetCallbackMethods(callbackType))
                     {
-                        var callback = await GenerateOperationAsync(type, callbackMethod, generator, resolver, SigSpecOperationType.Sync);
+                        var callback = GenerateOperation(callbackMethod, generator, resolver, SigSpecOperationType.Sync);
                         hub.Callbacks[callbackMethod.Name] = callback;
                     }
                 }
 
-                document.Hubs[h.Key] = hub;
+                document.Hubs[nameof(type)] = hub;
             }
-
             return document;
         }
 
-        private static IEnumerable<string> _forbiddenOperations { get; } = typeof(Hub).GetRuntimeMethods().Concat(typeof(Hub<>).GetRuntimeMethods()).Select(x => x.Name).Distinct();
-        private IEnumerable<MethodInfo> GetOperationMethods(Type type)
+        private IEnumerable<MethodInfo> GetHubMethods(Type type)
         {
             return type.GetTypeInfo().GetRuntimeMethods().Where(m =>
             {
                 var returnsChannelReader = m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() == typeof(ChannelReader<>);
                 return
-                    m.IsPublic &&
-                    m.IsSpecialName == false &&
-                    m.DeclaringType != typeof(Hub) &&
-                    m.DeclaringType != typeof(Hub<>) &&
-                    m.DeclaringType != typeof(object) &&
-                    !_forbiddenOperations.Contains(m.Name) &&
-                    returnsChannelReader == false;
+                    m.GetCustomAttribute<SigSpecRegisterAttribute>() != null &&
+                    !returnsChannelReader;
+            });
+        }
+
+        private IEnumerable<MethodInfo> GetCallbackMethods(Type type)
+        {
+            return type.GetTypeInfo().GetRuntimeMethods().Where(m =>
+            {
+                var returnsChannelReader = m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() == typeof(ChannelReader<>);
+                return !returnsChannelReader;
             });
         }
 
@@ -91,51 +93,55 @@ namespace SigSpec.Core
             return type.GetTypeInfo().GetRuntimeMethods().Where(m =>
             {
                 var returnsChannelReader = m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() == typeof(ChannelReader<>);
-                return
-                    m.IsPublic &&
-                    m.IsSpecialName == false &&
-                    m.DeclaringType != typeof(Hub) &&
-                    m.DeclaringType != typeof(Hub<>) &&
-                    m.DeclaringType != typeof(object) &&
-                    !_forbiddenOperations.Contains(m.Name) &&
-                    returnsChannelReader == true;
+                return m.GetCustomAttribute<SigSpecRegisterAttribute>() != null && returnsChannelReader;
             });
         }
 
-        private async Task<SigSpecOperation> GenerateOperationAsync(Type type, MethodInfo method, JsonSchemaGenerator generator, SigSpecSchemaResolver resolver, SigSpecOperationType operationType)
+        private Type GetReturnType(SigSpecOperationType operationType, MethodInfo method)
+        {
+            if (operationType == SigSpecOperationType.Observable)
+            {
+                return method.ReturnType.GetGenericArguments().First();
+            }
+            if (method.ReturnType == typeof(Task))
+            {
+                return null;
+            }
+            if (method.ReturnType.IsGenericType && method.ReturnType.BaseType == typeof(Task))
+            {
+                return method.ReturnType.GetGenericArguments().First();
+            }
+            return method.ReturnType;
+        }
+
+        private SigSpecOperation GenerateOperation(MethodInfo method, JsonSchemaGenerator generator, SigSpecSchemaResolver resolver, SigSpecOperationType operationType)
         {
             var operation = new SigSpecOperation
             {
-                Description = method.GetXmlDocsSummary(),
-                Type = operationType
+                    Description = method.GetXmlDocsSummary(),
+                    Type = operationType
             };
-
-            foreach (var arg in method.GetParameters().Where(param => param.ParameterType != typeof(CancellationToken)))
+                        
+            var ignoreParams = new List<Type> { typeof(CancellationToken), typeof(InvocationContext), typeof(ILogger) };
+            foreach (var arg in method.GetParameters().Where(param => !ignoreParams.Contains(param.ParameterType)))
             {
                 var parameter = generator.GenerateWithReferenceAndNullability<SigSpecParameter>(
                     arg.ParameterType.ToContextualType(), arg.ParameterType.ToContextualType().IsNullableType, resolver, (p, s) =>
                     {
-                        p.Description = arg.GetXmlDocs();
+                            p.Description = arg.GetXmlDocs();
                     });
 
                 operation.Parameters[arg.Name] = parameter;
             }
 
-            var returnType =
-                operationType == SigSpecOperationType.Observable
-                    ? method.ReturnType.GetGenericArguments().First()
-                : method.ReturnType == typeof(Task)
-                    ? null
-                : method.ReturnType.IsGenericType && method.ReturnType.BaseType == typeof(Task)
-                    ? method.ReturnType.GetGenericArguments().First()
-                    : method.ReturnType;
+            var returnType = GetReturnType(operationType, method);
 
-            operation.ReturnType = returnType == null ? null : generator.GenerateWithReferenceAndNullability<JsonSchema>(
-                returnType.ToContextualType(), returnType.ToContextualType().IsNullableType, resolver, async (p, s) =>
-                {
-                    p.Description = method.ReturnType.GetXmlDocsSummary();
-                });
-
+            if (operation.ReturnType != null)
+            {
+                generator.GenerateWithReferenceAndNullability<JsonSchema>(
+                returnType.ToContextualType(), returnType.ToContextualType().IsNullableType, resolver, (p, s) => 
+                    p.Description = method.ReturnType.GetXmlDocsSummary());
+            }
             return operation;
         }
     }


### PR DESCRIPTION
- liquid file `unregisterCallbacks` method no longer takes functional argument
- liquid file added typed parameter for callback method
- Generator now uses params instead of dictionary for registering hubs
- Generator support for Serverless Hubs
- [Breaking] Generator now relies on `SigSpecRegisterAttrbiute` to register methods for hub operations invokable by the client. Alternative was to introduce a `SigSpecIgnore`, but this was cleaner and easier. Necessary to help support serverless hubs and reduces code complexity
- Package updates